### PR TITLE
Allow retry for OSS risk audit if error is due to timeout

### DIFF
--- a/depscan/lib/config.py
+++ b/depscan/lib/config.py
@@ -296,5 +296,9 @@ pkg_max_risk_score = get_float_from_env("pkg_max_risk_score", 0.5)
 # Default request timeout
 request_timeout_sec = get_int_from_env("request_timeout_sec", 20)
 
+# Will try to query for each package up to this many times, if the reason for failure is timeout.
+# Retries excepted due to this do not contribute to the max_request_failures limit below.
+max_timeout_attempts = get_int_from_env("max_timeout_attempts", 3)
+
 # Number of api failures that would stop the risk audit completely
 max_request_failures = get_int_from_env("max_request_failures", 5)

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -80,7 +80,7 @@ def metadata_from_registry(registry_type, pkg_list, private_ns=None):
                         continue
                     # If no error, or error is not due to timeout, do not retry.
                     # Non-timeout errors will get caught by the enclosing try-except
-                    # and will contribute to the failure count.
+                    # and will contribute towards the failure count.
                     break
 
                 json_data = r.json()

--- a/depscan/lib/pkg_query.py
+++ b/depscan/lib/pkg_query.py
@@ -74,14 +74,14 @@ def metadata_from_registry(registry_type, pkg_list, private_ns=None):
                 # (note that the first attempt is not a retry)
                 # if the reason for failure is timeout
                 for attempt in range(config.max_timeout_attempts):
-                    try:
-                        r = requests.get(url=lookup_url, timeout=config.request_timeout_sec)
-                    except requests.Timeout:
-                        continue
-                    # If no error, or error is not due to timeout, do not retry.
                     # Non-timeout errors will get caught by the enclosing try-except
                     # and will contribute towards the failure count.
-                    break
+                    try:
+                        r = requests.get(url=lookup_url, timeout=config.request_timeout_sec)
+                        # If no error, do not retry.
+                        break
+                    except requests.Timeout:
+                        continue
 
                 json_data = r.json()
                 # Npm returns this error if the package is not found


### PR DESCRIPTION
I have set the [default number of retries](https://github.com/AppThreat/dep-scan/blob/7f3f63b484a06949221e82e300c4f9fc19ae7f99/depscan/lib/config.py) to 3, but obviously you can change this.