### PR TITLE
Filter vendor aliases that are also name aliases.

### DIFF
--- a/.github/workflows/pythonpublish.yml
+++ b/.github/workflows/pythonpublish.yml
@@ -11,7 +11,6 @@ on:
     tags:
       - 'v*' # Push events to matching v*, i.e. v1.0, v20.15.10
   workflow_dispatch:
-  pull_request:
 
 env:
   REGISTRY: ghcr.io

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -79,8 +79,6 @@ def create_pkg_variations(pkg_dict):
                 if tmpA[1] != name:
                     vendor_aliases.add(tmpA[1])
     # Add some common vendor aliases
-    if purl.startswith("pkg:composer") or purl.startswith("pkg:pypi"):
-        vendor_aliases.add(name)
     if purl.startswith("pkg:golang") and not name.startswith("go"):
         vendor_aliases.add("go")
         # Ignore third party alternatives for builtins
@@ -163,6 +161,9 @@ def create_pkg_variations(pkg_dict):
             name_aliases.add("lib" + name)
         if "-bin" not in name:
             name_aliases.add(name + "-bin")
+    else:
+        # Filter vendor aliases that are also name aliases
+        vendor_aliases = [x for x in vendor_aliases if x not in name_aliases]
     if len(vendor_aliases) > 0:
         for vvar in list(vendor_aliases):
             for nvar in list(name_aliases):

--- a/depscan/lib/normalize.py
+++ b/depscan/lib/normalize.py
@@ -91,7 +91,7 @@ def create_pkg_variations(pkg_dict):
             vendor_aliases.add("golang")
     if pkg_type not in config.OS_PKG_TYPES:
         name_aliases.add("package_" + name)
-        if not purl.startswith("pkg:golang"):
+        if purl.startswith("pkg:composer"):
             vendor_aliases.add("get" + name)
             vendor_aliases.add(name + "_project")
         for k, v in config.vendor_alias.items():

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "appthreat-depscan"
-version = "4.2.0"
+version = "4.2.1"
 description = "Fully open-source security audit for project dependencies based on known vulnerabilities and advisories."
 authors = [
     {name = "Team AppThreat", email = "cloud@appthreat.com"},


### PR DESCRIPTION
Also, use name_project alias in vendor only for composer. With better sources such as osv these aliasing can be tuned down further over time.
This will tune the FPs while dealing with application CVEs.
Fixes #113

@ashmedai @bh86 could you kindly test with this branch?